### PR TITLE
Add German learning materials website

### DIFF
--- a/german-learning/index.html
+++ b/german-learning/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>German Learning Materials</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <h1>German Learning Materials</h1>
+    <nav>
+      <ul>
+        <li><a href="#products">Products</a></li>
+        <li><a href="#contact">Contact</a></li>
+      </ul>
+    </nav>
+  </header>
+  <section class="hero">
+    <h2>Master German with our engaging resources</h2>
+    <p>From beginner to advanced, find the perfect materials to boost your language skills.</p>
+    <a href="#products" class="btn">Shop Now</a>
+  </section>
+
+  <main id="products">
+    <h2>Featured Products</h2>
+    <div class="product-grid">
+      <div class="product-card">
+        <h3>A1 Beginner Pack</h3>
+        <p>Essential grammar, vocabulary and exercises for starting German learners.</p>
+        <span class="price">$19.99</span>
+        <button class="buy-btn" data-product="A1 Beginner Pack">Buy Now</button>
+      </div>
+      <div class="product-card">
+        <h3>B1 Intermediate Course</h3>
+        <p>Improve your reading and speaking with our intermediate course.</p>
+        <span class="price">$29.99</span>
+        <button class="buy-btn" data-product="B1 Intermediate Course">Buy Now</button>
+      </div>
+      <div class="product-card">
+        <h3>German Verb Drills</h3>
+        <p>Practice verbs in every tense with these handy drills.</p>
+        <span class="price">$14.99</span>
+        <button class="buy-btn" data-product="German Verb Drills">Buy Now</button>
+      </div>
+    </div>
+  </main>
+
+  <section id="contact">
+    <h2>Contact Us</h2>
+    <p>Questions or custom requests? Send us an email at <a href="mailto:info@germanmaterials.example">info@germanmaterials.example</a></p>
+  </section>
+
+  <footer>
+    <p>&copy; 2024 German Learning Materials</p>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/german-learning/script.js
+++ b/german-learning/script.js
@@ -1,0 +1,9 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const buttons = document.querySelectorAll('.buy-btn');
+  buttons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const product = btn.dataset.product;
+      alert(`Thank you for your interest in ${product}! Please contact us at info@germanmaterials.example to complete your purchase.`);
+    });
+  });
+});

--- a/german-learning/styles.css
+++ b/german-learning/styles.css
@@ -1,0 +1,68 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  line-height: 1.6;
+  color: #333;
+}
+header {
+  background: #004d40;
+  color: #fff;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+}
+header nav ul {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+}
+header nav a {
+  color: #fff;
+  text-decoration: none;
+}
+.hero {
+  background: url('https://source.unsplash.com/featured/?germany') center/cover no-repeat;
+  color: #fff;
+  text-align: center;
+  padding: 4rem 1rem;
+}
+.hero .btn {
+  background: #ff9800;
+  color: #fff;
+  padding: 0.75rem 1.5rem;
+  text-decoration: none;
+  border-radius: 4px;
+  display: inline-block;
+  margin-top: 1rem;
+}
+.product-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+  padding: 2rem;
+}
+.product-card {
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 1rem;
+  text-align: center;
+}
+.price {
+  font-weight: bold;
+  display: block;
+  margin: 0.5rem 0;
+}
+.buy-btn {
+  background: #004d40;
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  border-radius: 4px;
+}
+footer {
+  text-align: center;
+  padding: 1rem;
+  background: #f5f5f5;
+}


### PR DESCRIPTION
## Summary
- create static site with landing page and product listings for German learning materials
- add basic styling and simple buy button interactions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adcec438648327b117083b6ee8e982